### PR TITLE
chore: remove not needed --crossplatform param

### DIFF
--- a/.github/workflows/deploy-with-version.yml
+++ b/.github/workflows/deploy-with-version.yml
@@ -83,7 +83,6 @@ jobs:
         run: >
           npx @dcl/opscli queue-ab-conversion-about \
             --token ${{ secrets.AB_TOKEN }} \
-            --crossplatform \
             --prioritize \
             --about-url ${{ secrets.SDK_TEAM_S3_BASE_URL }}/ipfs/${{steps.get-branch-realm-name.outputs.result}}/about
 


### PR DESCRIPTION
Now that --crossplatform is default in opscli, we remove the param