### PR TITLE
fix: trigger event on Party Time

### DIFF
--- a/Party-Time/src/index.ts
+++ b/Party-Time/src/index.ts
@@ -22,7 +22,7 @@ const partyEnd = new Date('2023-11-01T02:00:00+03:00') // GMT+3
 async function addStartNowButton() {
   const realm = await getRealm({})
   const realmBaseUrl = (realm.realmInfo?.baseUrl ?? 'https://peer.decentraland.org').toLocaleLowerCase()
-  const possibleTestEnvironments = ['goerli-plaza', 'localhost', '192.', '127.']
+  const possibleTestEnvironments = ['goerli-plaza', 'localhost', '192.', '127.', 'sdk-team-cdn']
 
   // Only possible test environments can force start the party
   if (!possibleTestEnvironments.some((value) => realmBaseUrl.includes(value))) {


### PR DESCRIPTION
The scene filters some environments comparing those to what `getRealm({})` returns. I updated the list of test environments to include `sdk-team-cdn` and now the white cube to trigger the party is enabled again.

Fixes: https://github.com/decentraland/unity-explorer/issues/1703

### QA STEPS
- The goerli repository creates 2 ways to test PRs, please ignore those since they are outdated
- Open the client (latest live prod version)
- In the chat, enter this command: `/goto https://sdk-team-cdn.decentraland.org/ipfs/goerli-plaza-fix-trigger-event-on-PartyTi-latest`
- Once Goerli loads, verify you're in this branch version by checking the top name:
![image](https://github.com/user-attachments/assets/16413371-191f-48be-80ec-ffa285d056d0)
- Now enter in the chat: `/goto-local 77,1`
- Verify the cube is there

#### Note
If the scene is missing assets (like the tree, sign, and so on), do `/reload` and wait a few seconds, and repeat until the scene properly loads