### PR TITLE
chore: update pr build test instructions

### DIFF
--- a/.github/workflows/deploy-with-version.yml
+++ b/.github/workflows/deploy-with-version.yml
@@ -103,9 +103,9 @@ jobs:
           body: |
             ## Test this pull request
             - [Test in-world](https://play.decentraland.zone/?realm=${{ secrets.SDK_TEAM_S3_BASE_URL }}/ipfs/${{steps.get-branch-realm-name.outputs.result}})
-            - Or use this command to switch the realm
+            - Or use this chat command to switch the realm
               ```bash
-              /changerealm ${{ secrets.SDK_TEAM_S3_BASE_URL }}/ipfs/${{steps.get-branch-realm-name.outputs.result}}
+              /goto ${{ secrets.SDK_TEAM_S3_BASE_URL }}/ipfs/${{steps.get-branch-realm-name.outputs.result}}
               ```
             This PR has been published using the `@dcl/sdk` version `${{ inputs.dcl-sdk-package }}`
           edit-mode: replace


### PR DESCRIPTION
Test instructions auto-generated for PRs included outdated commands for the old explorer.
This PR updates those instructions for the new explorer.