### PR TITLE
fix: limit asset-bundle trigger

### DIFF
--- a/.github/workflows/deploy-with-version.yml
+++ b/.github/workflows/deploy-with-version.yml
@@ -79,6 +79,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SDK_TEAM_AWS_SECRET }}
 
       - name: Asset Bundle converter queue AllPlataforms
+        if: github.event_name != 'pull_request'
         run: >
           npx @dcl/opscli queue-ab-conversion-about \
             --token ${{ secrets.AB_TOKEN }} \


### PR DESCRIPTION
### Skip Asset Bundle Conversion on Pull Requests

- The `Asset Bundle converter queue AllPlataforms` step in `deploy-with-version.yml` is now conditionally executed only on push events (i.e., when merging to main).
- This prevents triggering asset bundle conversion during pull request builds, which are used only for preview purposes and not real deployments.
- By skipping unnecessary conversions on PRs, this change reduces noise in the AB queue and avoids redundant S3 uploads, resulting in cost savings on AWS usage.