### PR TITLE
fix: correct rotating platforms test scene rotation axis

### DIFF
--- a/rotating-platforms/src/rotatingPlatform.ts
+++ b/rotating-platforms/src/rotatingPlatform.ts
@@ -32,22 +32,22 @@ export function createRotatingPlatform(
 
   switch (direction) {
     case Direction.X:
-      directionQuat = Quaternion.fromEulerDegrees(0, 0, 90)
+      directionQuat = Quaternion.fromEulerDegrees(-90, 0, 0)
       break
     case Direction.invX:
-      directionQuat = Quaternion.fromEulerDegrees(0, 0, -90)
+      directionQuat = Quaternion.fromEulerDegrees(90, 0, 0)
       break
     case Direction.Y:
       directionQuat = Quaternion.fromEulerDegrees(0, 90, 0)
       break
     case Direction.invY:
-      directionQuat = Quaternion.fromEulerDegrees(0, -90, 0)
+      directionQuat = Quaternion.fromEulerDegrees(0, 90, 0)
       break
     case Direction.Z:
-      directionQuat = Quaternion.fromEulerDegrees(90, 0, 0)
+      directionQuat = Quaternion.fromEulerDegrees(0, 0, 90)
       break
     case Direction.invZ:
-      directionQuat = Quaternion.fromEulerDegrees(-90, 0, 0)
+      directionQuat = Quaternion.fromEulerDegrees(0, 0, -90)
       break
   }
 


### PR DESCRIPTION
Explorer now derives the continuous-rotation axis from the quaternion's imaginary part (previously it rotated Vector3.up by the quaternion, which masked sign and swapped axes). 

Picked euler angles so the imaginary part equals the visual axis the old code produced for this scene, preserving the deployed behavior.

Once re-deployed with this change, the test scene will work correctly with Explorer `v0.141` (contains the rotation fix) and wrong with the previous Explorer versions that have the bug on the continuous tween rotators.